### PR TITLE
Fix selectPaymentRequirements mutation bug

### DIFF
--- a/typescript/packages/x402/src/client/selectPaymentRequirements.test.ts
+++ b/typescript/packages/x402/src/client/selectPaymentRequirements.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "vitest";
+import { selectPaymentRequirements } from "./selectPaymentRequirements";
+import { PaymentRequirements } from "../types";
+
+describe("selectPaymentRequirements", () => {
+  it("should not mutate the input array", () => {
+    const requirements: PaymentRequirements[] = [
+      {
+        scheme: "exact",
+        network: "iotex",
+        maxAmountRequired: "1",
+        resource: "res1",
+        description: "d",
+        mimeType: "application/json",
+        payTo: "0x1111111111111111111111111111111111111111",
+        maxTimeoutSeconds: 1,
+        asset: "0x1111111111111111111111111111111111111111",
+      },
+      {
+        scheme: "exact",
+        network: "base",
+        maxAmountRequired: "1",
+        resource: "res2",
+        description: "d",
+        mimeType: "application/json",
+        payTo: "0x2222222222222222222222222222222222222222",
+        maxTimeoutSeconds: 1,
+        asset: "0x2222222222222222222222222222222222222222",
+      },
+    ];
+    const original = requirements.map(r => ({ ...r }));
+    const selected = selectPaymentRequirements(requirements);
+    expect(selected).toEqual(requirements[1]);
+    expect(requirements).toEqual(original);
+  });
+});

--- a/typescript/packages/x402/src/client/selectPaymentRequirements.ts
+++ b/typescript/packages/x402/src/client/selectPaymentRequirements.ts
@@ -14,7 +14,7 @@ import { getNetworkId } from "../shared/network";
  */
 export function selectPaymentRequirements(paymentRequirements: PaymentRequirements[], network?: Network, scheme?: "exact"): PaymentRequirements {
   // Sort `base` payment requirements to the front of the list. This is to ensure that base is preferred if available.
-  paymentRequirements.sort((a, b) => {
+  const sortedRequirements = [...paymentRequirements].sort((a, b) => {
     if (a.network === "base" && b.network !== "base") {
       return -1;
     }
@@ -25,7 +25,7 @@ export function selectPaymentRequirements(paymentRequirements: PaymentRequiremen
   });
 
   // Filter down to the scheme/network if provided
-  const broadlyAcceptedPaymentRequirements = paymentRequirements.filter(requirement => {
+  const broadlyAcceptedPaymentRequirements = sortedRequirements.filter(requirement => {
     // If the scheme is not provided, we accept any scheme.
     const isExpectedScheme = !scheme || requirement.scheme === scheme;
     // If the chain is not provided, we accept any chain.
@@ -51,7 +51,7 @@ export function selectPaymentRequirements(paymentRequirements: PaymentRequiremen
   }
 
   // If no matching requirements are found, return the first requirement.
-  return paymentRequirements[0];
+  return sortedRequirements[0];
 }
 
 /**


### PR DESCRIPTION
## Summary
- avoid mutating input array in `selectPaymentRequirements`
- add regression test for `selectPaymentRequirements`

## Testing
- `pnpm -r test`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6840d120309c8328a87d52c4591ef1e5